### PR TITLE
6/login ap iprototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ npm install
 npm run start-dev
 ```
 
+### DB初期化＋テスト用データ投入
+
+```
+npm run init-db
+```
+
 ### ログイン [POST /login]
 
 * header
@@ -50,9 +56,10 @@ npm run start-dev
     "user": {
         "name": "Taro Yamada",
         "email": "foo@example.com",
+        "group": "group12345", // グループID
     }
     "_links": {
-        "self" : { 
+        "self" : {
             "method": "GET",
             "href": "/me",
             "headers": {
@@ -77,7 +84,6 @@ npm run start-dev
 
 |key|value|
 |:--|:----|
-|Content-Type|Application/json|
 |X-Meshido-ApiVerion|1.0|
 |X-Meshido-UserToken|[/login]で取得したtoken|
 
@@ -156,7 +162,7 @@ dayまで指定すると、その日だけ取ってくる。
         :
     },
     "_links": {
-        "self" : { 
+        "self" : {
             "method": "GET",
             "href": "/group/group12345/calendar/year/2015/month/12",
             "headers": {
@@ -165,7 +171,7 @@ dayまで指定すると、その日だけ取ってくる。
                 "X-Meshido-UsrToken" : "token12345"
             }
         },
-        "next" : { 
+        "next" : {
             "method": "GET",
             "href": "/group/group12345/calendar/year/2016/month/1",
             "headers": {
@@ -174,7 +180,7 @@ dayまで指定すると、その日だけ取ってくる。
                 "X-Meshido-UsrToken" : "token12345"
             }
         },
-        "prev" : { 
+        "prev" : {
             "method": "GET",
             "href": "/group/group12345/calendar/year/2015/month/11",
             "headers": {
@@ -285,13 +291,12 @@ dayまで指定すると、その日だけ取ってくる。
 
 |key|value|
 |:--|:----|
-|Content-Type|Application/json|
 |X-Meshido-ApiVerion|1.0|
 |X-Meshido-UserToken|[/login]で取得したtoken|
 
 * parameters
 
-no parameters needed.
+なし
 
 * response
 
@@ -302,6 +307,7 @@ no parameters needed.
     "user" : {
         "name": "Taro Yamada",
         "email": "hogehoge@example.com",
+        "group": "group12345",
     },
     "_links": {
         "method": "GET",

--- a/app.js
+++ b/app.js
@@ -4,7 +4,6 @@ var path = require('path');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
-var session = require('express-session');
 
 var routes = require('./routes/index');
 var users = require('./routes/users');
@@ -22,15 +21,6 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: false}));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
-
-app.use(session({
-  secret: 'meshido-secret-key',
-  resave: false,
-  saveUninitialized: false,
-  cookie: {
-    maxAge: 30 * 60 * 1000
-  }
-}));
 
 app.use('/', routes);
 app.use('/users', users);

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
+var session = require('express-session');
 
 var routes = require('./routes/index');
 var users = require('./routes/users');
@@ -21,6 +22,15 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+
+app.use(session({
+  secret: 'meshido-secret-key',
+  resave: false,
+  saveUninitialized: false,
+  cookie: {
+    maxAge: 30 * 60 * 1000
+  }
+}));
 
 app.use('/', routes);
 app.use('/users', users);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cookie-parser": "~1.3.5",
     "debug": "~2.2.0",
     "express": "~4.13.1",
+    "express-session": "^1.12.1",
     "jade": "~1.11.0",
     "mongodb": "^2.0.49",
     "mongoskin": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "start": "node ./bin/www",
     "start-dev": "node-dev ./bin/www",
     "gulp": "gulp",
-    "lint": "gulp lint"
+    "lint": "gulp lint",
+    "init-db": "node ./tools/dbInit.js"
   },
   "dependencies": {
+    "bluebird": "^3.0.6",
     "body-parser": "~1.13.2",
     "cookie-parser": "~1.3.5",
     "debug": "~2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "mongoskin": "~2.0.3",
     "morgan": "~1.6.1",
     "node-dev": "^2.7.1",
+    "rand-token": "^0.2.1",
     "serve-favicon": "~2.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "morgan": "~1.6.1",
     "node-dev": "^2.7.1",
     "rand-token": "^0.2.1",
-    "serve-favicon": "~2.3.0"
+    "serve-favicon": "~2.3.0",
+    "validator": "^4.4.0"
   },
   "devDependencies": {
     "eslint-config-xo": "^0.8.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,6 +6,7 @@ var mongoskin = require('mongoskin');
 var db = mongoskin.db('mongodb://localhost:27017/meshido');
 var bluebird = require('bluebird');
 bluebird.promisifyAll(mongoskin);
+var validator = require('validator');
 
 var API_VERSION = '1.0';
 
@@ -16,9 +17,37 @@ router.get('/', function (req, res) {
 	});
 });
 
+/**
+ * validate login params
+ */
+var isValidLoginParameters = function (req) {
+	var isValid = true;
+	if (validator.isNull(req.body.name)) {
+		isValid = false;
+	}
+	if (validator.isNull(req.body.email)) {
+		isValid = false;
+	}
+	if (!validator.isEmail(req.body.email)) {
+		isValid = false;
+	}
+	if (validator.isNull(req.body.group)) {
+		isValid = false;
+	}
+	return isValid;
+};
+
+/**
+ * login
+ */
 router.post('/login', function (req, res) {
-	// <TODO> accepting request and validation
+	// accepting request and validation
 	// <TODO> 上位処理に移行予定
+	if (!isValidLoginParameters(req)) {
+		var errBody = {error: 'some parameters are not correct.'};
+		res.status(400).send(errBody);
+		return;
+	}
 
 	// generate token
 	var userToken = randtoken.uid(24);
@@ -75,6 +104,9 @@ router.post('/login', function (req, res) {
 	});
 });
 
+/**
+ * getting authorized user json
+ */
 router.get('/me', function (req, res) {
 	// accepting request and validation
 	// <TODO> 上位処理に移行予定
@@ -131,6 +163,9 @@ router.get('/me', function (req, res) {
 	);
 });
 
+/**
+ * logout
+ */
 router.get('/logout', function (req, res) {
 	// accepting request and validation
 	// <TODO> 上位処理に移行予定

--- a/routes/index.js
+++ b/routes/index.js
@@ -17,6 +17,7 @@ router.get('/', function (req, res) {
 
 router.post('/login', function (req, res) {
 	// <TODO> accepting request and validation
+	// <TODO> 上位処理に移行予定
 
 	// generate token
 	var userToken = randtoken.uid(24);
@@ -37,29 +38,84 @@ router.post('/login', function (req, res) {
 		if (result) {
 			console.log('add new user [' + result.insertedIds + ']');
 		}
+
+		// create response body
+		var response = {
+			v: API_VERSION,
+			token: userToken,
+			user: newUser,
+			_links: {
+				self: {
+					method: 'GET',
+					href: '/me',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-Meshido-ApiVerion': API_VERSION,
+						'X-Meshido-UserToken': newUser.token
+					},
+					parameters: ''
+				}
+			},
+			_embeded: ''
+		};
+
+		res.send(response);
 	});
+});
 
-	// create response body
-	var response = {
-		v: API_VERSION,
-		token: userToken,
-		user: newUser,
-		_links: {
-			self: {
-				method: 'GET',
-				href: '/me',
-				headers: {
-					'Content-Type': 'application/json',
-					'X-Meshido-ApiVerion': API_VERSION,
-					'X-Meshido-UsrToken': newUser.token
-				},
-				parameters: ''
+router.get('/me', function (req, res) {
+	// accepting request and validation
+	// <TODO> 上位処理に移行予定
+	var xToken = req.get('X-Meshido-UserToken');
+	if (xToken === undefined) {
+		var errBody = {error: 'no token was send.'};
+		res.status(400).send(errBody);
+		return;
+	}
+
+	// find an user by token in request header
+	db.user.findOne({token: xToken},
+		function (err, result) {
+			if (err) {
+				console.log('faild to retrieve user');
+				throw err;
 			}
-		},
-		_embeded: ''
-	};
 
-	res.send(response);
+			// no result
+			if (result === null) {
+				var errBody = {error: 'user does not exist.'};
+				res.status(401).send(errBody);
+				return;
+			}
+
+			// exists.
+			var me = {
+				name: result.name,
+				email: result.email
+			};
+
+			// create response body
+			var response = {
+				v: API_VERSION,
+				user: me,
+				_links: {
+					self: {
+						method: 'GET',
+						href: '/me',
+						headers: {
+							'Content-Type': 'application/json',
+							'X-Meshido-ApiVerion': API_VERSION,
+							'X-Meshido-UserToken': xToken
+						},
+						parameters: ''
+					}
+				},
+				_embeded: ''
+			};
+
+			res.send(response);
+		}
+	);
 });
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -103,7 +103,8 @@ router.get('/me', function (req, res) {
 			// exists.
 			var me = {
 				name: result.name,
-				email: result.email
+				email: result.email,
+				group: result.group
 			};
 
 			// create response body

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,4 +6,64 @@ router.get('/', function(req, res, next) {
   res.render('index', { title: 'Express' });
 });
 
+router.post('/login', function(req, res, next) {
+  req.session.user = {
+    name: req.body.name,
+    email: req.body.email,
+    groupe: req.body.group,
+  };
+
+  var response =   {
+    "user": {
+        "name": req.session.user.name,
+        "email": req.session.user.email,
+    },
+    "_links": {
+        "self" : { "method": "GET", "href": "/me" },
+        "calendar" : { "method": "GET", "href": "/group/group12345/calender" },
+        "logout" : { "method": "GET", "href": "/logout" },
+    },
+    "_embeded": "",
+  }
+
+  res.send(response);
+});
+
+router.get('/me', function(req, res, next) {
+
+  var response = "";
+  if (req.session.user) {
+    response =   {
+      "user": {
+          "name": req.session.user.name,
+          "email": req.session.user.email,
+      },
+      "_links": {
+          "self" : { "method": "GET", "href": "/me" },
+      },
+      "_embeded": "",
+    }
+  } else {
+    response =   {
+      "_links": {
+          "self" : { "method": "GET", "href": "/me" },
+      },
+      "_embeded": "",
+    }
+  }
+
+  res.send(response);
+});
+
+router.get('/logout', function(req, res, next) {
+  req.session.destroy();
+
+  var response =   {
+    "_links": "",
+    "_embeded": "",
+  }
+
+  res.send(response);
+});
+
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -118,4 +118,33 @@ router.get('/me', function (req, res) {
 	);
 });
 
+router.get('/logout', function (req, res) {
+	// accepting request and validation
+	// <TODO> 上位処理に移行予定
+	var xToken = req.get('X-Meshido-UserToken');
+	if (xToken === undefined) {
+		var errBody = {error: 'no token was send.'};
+		res.status(400).send(errBody);
+		return;
+	}
+
+	db.user.remove({token: xToken},
+		function (err, result) {
+			if (err) {
+				console.log('faild to retrieve user');
+				throw err;
+			}
+
+			// create response body
+			var response = {
+				v: API_VERSION,
+				message: "logout was succeeded."
+			};
+
+			res.send(response);
+		}
+	);
+});
+
+
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -129,7 +129,7 @@ router.get('/logout', function (req, res) {
 	}
 
 	db.user.remove({token: xToken},
-		function (err, result) {
+		function (err) {
 			if (err) {
 				console.log('faild to retrieve user');
 				throw err;
@@ -138,13 +138,12 @@ router.get('/logout', function (req, res) {
 			// create response body
 			var response = {
 				v: API_VERSION,
-				message: "logout was succeeded."
+				message: 'logout was succeeded.'
 			};
 
 			res.send(response);
 		}
 	);
 });
-
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -60,33 +60,39 @@ router.post('/login', function (req, res) {
 		token: userToken
 	};
 
-	// check if group is exists.
-	db.collection('groups').findOneAsync({id: newUser.group})
-	.then(function (result) {
-		if (result === null) {
-			var errBody = {error: 'group does not exists.'};
-			res.status(404).send(errBody);
-			return Promise.reject(errBody);
-		}
-
+	Promise.resolve()
+	.then(function () {
+		// check if group is exists.
+		return db.collection('groups').findOneAsync({id: newUser.group})
+			.then(function (result) {
+				if (result === null) {
+					var errBody = {error: 'group does not exists.'};
+					res.status(404).send(errBody);
+					return Promise.reject(errBody);
+				}
+			});
+	})
+	.then(function () {
 		// check if user has been already exists
-		return db.collection('users').findOneAsync({email: newUser.email, group: newUser.group});
+		return db.collection('users').findOneAsync({email: newUser.email, group: newUser.group})
+			.then(function (result) {
+				if (result !== null) {
+					var errBody = {error: 'user has been already exist.'};
+					res.status(409).send(errBody);
+					return Promise.reject(errBody);
+				}
+			});
 	})
-	.then(function (result) {
-		if (result !== null) {
-			var errBody = {error: 'user has been already exist.'};
-			res.status(409).send(errBody);
-			return Promise.reject(errBody);
-		}
-
+	.then(function () {
 		// insert new user record
-		return db.collection('users').insertAsync(newUser);
+		return db.collection('users').insertAsync(newUser)
+			.then(function (result) {
+				if (result) {
+					console.log('add new user [' + result.insertedIds + ']');
+				}
+			});
 	})
-	.then(function (result) {
-		if (result) {
-			console.log('add new user [' + result.insertedIds + ']');
-		}
-
+	.then(function () {
 		var me = {
 			name: newUser.name,
 			email: newUser.email,

--- a/tools/dbInit.js
+++ b/tools/dbInit.js
@@ -1,0 +1,34 @@
+var mongoskin = require('mongoskin');
+var db = mongoskin.db('mongodb://localhost:27017/meshido');
+var bluebird = require('bluebird');
+bluebird.promisifyAll(mongoskin);
+
+// initializing in serial
+console.log('remove all user data');
+db.collection('users').removeAsync()
+.then(function () {
+	console.log('remove all groups data');
+	return db.collection('groups').find().toArrayAsync();
+})
+.then(function () {
+	console.log('remove all events data');
+	return db.collection('events').find().toArrayAsync();
+})
+.then(function () {
+	console.log('insert initial data for group');
+	return db.collection('groups').insertAsync({groupId: 'test1', name: 'テストグループ1'});
+})
+.then(function () {
+	console.log('insert initial data for group');
+	return db.collection('groups').insertAsync({groupId: 'test2', name: 'テストグループ2'});
+})
+
+.then(function () {
+	console.log('done initializing db');
+	process.exit();
+})
+.catch(function (err) {
+	console.log(err);
+	process.exit();
+});
+

--- a/tools/dbInit.js
+++ b/tools/dbInit.js
@@ -16,11 +16,11 @@ db.collection('users').removeAsync()
 })
 .then(function () {
 	console.log('insert initial data for group');
-	return db.collection('groups').insertAsync({groupId: 'test1', name: 'テストグループ1'});
+	return db.collection('groups').insertAsync({id: 'test1', name: 'テストグループ1'});
 })
 .then(function () {
 	console.log('insert initial data for group');
-	return db.collection('groups').insertAsync({groupId: 'test2', name: 'テストグループ2'});
+	return db.collection('groups').insertAsync({id: 'test2', name: 'テストグループ2'});
 })
 
 .then(function () {


### PR DESCRIPTION
以下のAPIのプロトタイプです。
ログイン・ユーザー情報取得・ログアウト（デバッグ用につけました）

と、いいつつこのまま時間切れになる気がしないでもないですが、MVCを完全にスルーしてます。
残タスクとしては
- バージョニング（もう現時点でパラメータとしては貰うけど何もしない感じになりそう）
- リファクタリング（特にリクエストの評価、エラーハンドリング、DBまわりなどは見直したい）
- 異例ケース対応（あれば）
  くらいです。
## 確認項目
### DBの初期化スクリプトが動くことを確認して下さい

`npm run init-db` を実行してエラーが発生しないこと
### 以下のAPIについてRequestとResponseを確認して下さい
#### /login

(1) 正常系
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "山田太郎",
    "email": "taro@example.com",
    "group": "test1"
 }
```

Response

```
StatusCode:200
Body: 期待通りか（というPRの書き方はNG？細かく書くとただの結合試験になりそう）
```

(2) 異常系
以下のケースでResponseが「400 Bad Request」になること
 nameがないor空
 emailがないor空orメールアドレスじゃない
 groupがないor空

以下のケースでResponseが「404 Not Found」になること
 groupが存在しない(`npm run init-db`で`test1`と`test2`を登録済み)
#### /me

(1-1) 正常系
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [/loginのResponseで得られたtoken]
Body
 なし
```

Response

```
StatusCode:200
Body: 期待通りか
```

(1-2) 正常系(未認証)
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: aaaaaaaaaaaaaaaa
Body
 なし
```

Response

```
StatusCode:401
```

(2) 異常系
以下のケースでResponseが「400 Bad Request」になること
 tokenがない
#### /logout

(1) 正常系
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [/loginのResponseで得られたtoken]
Body
 なし
```

Response

```
StatusCode:200
```

⇛logout後に、同じtokenを使って「/me」を実行して401が返ってくること

(2) 異常系
以下のケースでResponseが「400 Bad Request」になること
 tokenがない
