### PR TITLE
add node-config and config files for each environment

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,3 +57,10 @@ app.use(function (err, req, res) {
 });
 
 module.exports = app;
+
+// starting log
+console.log('--- Meshido backend starting. ---');
+console.log(' env:NODE_ENV=' + process.env.NODE_ENV);
+console.log(' env:MONGO_URI=' + process.env.MONGO_URI);
+console.log(' env:TZ=' + process.env.TZ);
+console.log('---------------------------------');

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,5 @@
+{
+	"app": {
+		"info": "for default"
+	}
+}

--- a/config/development.json
+++ b/config/development.json
@@ -1,0 +1,5 @@
+{
+	"app": {
+		"info": "for development"
+	}
+}

--- a/config/heroku.json
+++ b/config/heroku.json
@@ -1,0 +1,5 @@
+{
+	"app": {
+		"info": "for heroku"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "start": "NODE_ENV=heroku node ./bin/www",
-    "start-dev": "NODE_ENV=development node-dev ./bin/www",
+    "start": "node ./bin/www",
+    "start-dev": "NODE_ENV='development' MONGO_URI='mongodb://localhost:27017/meshido' TZ='Asia/Tokyo' node-dev ./bin/www",
     "gulp": "gulp",
     "lint": "gulp lint",
     "init-db": "node ./tools/dbInit.js"

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www",
-    "start-dev": "node-dev ./bin/www",
+    "start": "NODE_ENV=heroku node ./bin/www",
+    "start-dev": "NODE_ENV=development node-dev ./bin/www",
     "gulp": "gulp",
     "lint": "gulp lint"
   },
   "dependencies": {
     "body-parser": "~1.13.2",
+    "config": "^1.17.1",
     "cookie-parser": "~1.3.5",
     "debug": "~2.2.0",
     "express": "~4.13.1",

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,9 +2,9 @@ var express = require('express');
 var router = express.Router();
 var config = require('config');
 var randtoken = require('rand-token');
-
 var mongoskin = require('mongoskin');
-var db = mongoskin.db('mongodb://localhost:27017/meshido');
+var mongoURI = process.env.MONGO_URI || 'mongodb://localhost:27017/meshido';
+var db = mongoskin.db(mongoURI);
 var bluebird = require('bluebird');
 bluebird.promisifyAll(mongoskin);
 var validator = require('validator');

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,10 +1,11 @@
 var express = require('express');
 var router = express.Router();
+var config = require('config');
 
 /* GET home page. */
 router.get('/', function (req, res) {
 	res.render('index', {
-		title: 'Express'
+		title: 'Express(' + config.app.info + ')'
 	});
 });
 

--- a/tools/dbInit.js
+++ b/tools/dbInit.js
@@ -1,5 +1,13 @@
+// starting log
+console.log('--- Meshido DB initializing. ---');
+console.log(' env:NODE_ENV=' + process.env.NODE_ENV);
+console.log(' env:MONGO_URI=' + process.env.MONGO_URI);
+console.log(' env:TZ=' + process.env.TZ);
+console.log('--------------------------------');
+
 var mongoskin = require('mongoskin');
-var db = mongoskin.db('mongodb://localhost:27017/meshido');
+var mongoURI = process.env.MONGO_URI || 'mongodb://localhost:27017/meshido';
+var db = mongoskin.db(mongoURI);
 var bluebird = require('bluebird');
 bluebird.promisifyAll(mongoskin);
 


### PR DESCRIPTION
### 何したか
- node-configの導入
- develop用とheroku用のconfig追加
- 起動スクリプトに環境変数を渡すうようにした
### 確認項目
1. `https://github.com/TeijigoTeaTime/meshido-backend.git`をclone
2. `npm install`を実行
3. `npm start`を実行
4. `http://localhost:3000/`にアクセス「Express(for heroku)」と表示されることを確認
5. サーバーを止め、`npm run start-dev`を実行
6. `http://localhost:3000/`にアクセス「Express(for develop)」と表示されることを確認
### 確認項目(追加)
1. `npm run start-dev`を実行
2. ログに以下の通り出力されること

```
--- Meshido backend starting. ---
 env:NODE_ENV=development
 env:MONGO_URI=mongodb://localhost:27017/meshido
 env:TZ=Asia/Tokyo
---------------------------------
```
