### PR TITLE
9/join api prototype

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ var bodyParser = require('body-parser');
 
 var routes = require('./routes/index');
 var users = require('./routes/users');
+var group = require('./routes/group');
 
 var app = express();
 
@@ -24,6 +25,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', routes);
 app.use('/users', users);
+app.use('/group', group);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express-session": "^1.12.1",
     "jade": "~1.11.0",
     "kerberos": "~0.0.17",
+    "moment": "^2.10.6",
     "mongodb": "~2.0.50",
     "mongoskin": "~2.0.3",
     "morgan": "~1.6.1",

--- a/routes/group.js
+++ b/routes/group.js
@@ -216,7 +216,7 @@ router.post('/:group/event/join', function (req, res) {
 						// initialize default data
 						days.push(
 							{
-								dayOfMonth: parseInt(date.format('D')),
+								dayOfMonth: parseInt(date.format('D'), 10),
 								weekday: date.format('ddd'),
 								dinner: {
 									hasJoined: false,

--- a/routes/group.js
+++ b/routes/group.js
@@ -1,0 +1,132 @@
+var express = require('express');
+var router = express.Router();
+
+var mongoskin = require('mongoskin');
+var db = mongoskin.db('mongodb://localhost:27017/meshido');
+var bluebird = require('bluebird');
+bluebird.promisifyAll(mongoskin);
+var validator = require('validator');
+
+// var API_VERSION = '1.0';
+
+/**
+ * validate join params
+ */
+var isValidJoinParameters = function (req) {
+	var isValid = true;
+	if (validator.isNull(req.params.group)) {
+		isValid = false;
+	}
+	if (validator.isNull(req.body.year)) {
+		isValid = false;
+	}
+	if (validator.isNull(req.body.month)) {
+		isValid = false;
+	}
+	if (validator.isNull(req.body.day)) {
+		isValid = false;
+	}
+	if (req.body.eventType !== 'lunch' && req.body.eventType !== 'dinner') {
+		isValid = false;
+	}
+	if (!validator.isDate(req.body.year + '-' + req.body.month + '-' + req.body.day)) {
+		isValid = false;
+	}
+	return isValid;
+};
+
+/**
+ * join event
+ */
+router.post('/:group/event/join', function (req, res) {
+	// accepting request and validation
+	// <TODO> 上位処理に移行予定
+	if (!isValidJoinParameters(req)) {
+		res.status(400).send({error: 'some parameters are not correct.'});
+		return;
+	}
+
+	var xToken = req.get('X-Meshido-UserToken');
+	if (xToken === undefined) {
+		res.status(401).send({error: 'no token was send.'});
+		return;
+	}
+
+	var user = [];
+
+	Promise.resolve()
+	.then(function () {
+		// check if group exists.
+		return db.collection('groups').findOneAsync({id: req.params.group})
+			.then(function (result) {
+				if (result === null) {
+					var errBody = {error: 'group does not exists.'};
+					res.status(404).send(errBody);
+					return Promise.reject(errBody);
+				}
+			});
+	})
+	.then(function () {
+		// check if user exists
+		return db.collection('users').findOneAsync({token: xToken})
+			.then(function (result) {
+				if (result === null) {
+					var errBody = {error: 'user does not exists.'};
+					res.status(404).send(errBody);
+					return Promise.reject(errBody);
+				}
+
+				user = result;
+			});
+	})
+	.then(function () {
+		// check if user has already joined
+		return db.collection('events').findOneAsync(
+			{
+				'group': req.params.group,
+				'year': req.body.year,
+				'month': req.body.month,
+				'day': req.body.day,
+				'type': req.body.eventType,
+				'user.email': user.email
+			}
+		)
+			.then(function (result) {
+				if (result !== null) {
+					var errBody = {error: 'user has already joined.'};
+					res.status(401).send(errBody);
+					return Promise.reject(errBody);
+				}
+			});
+	})
+	.then(function () {
+		// join event
+		var event = {
+			group: req.params.group,
+			year: req.body.year,
+			month: req.body.month,
+			day: req.body.day,
+			type: req.body.eventType,
+			user: {
+				name: user.name,
+				email: user.email
+			}
+		};
+
+		return db.collection('events').insertAsync(event)
+			.then(function (result) {
+				if (result) {
+					console.log('add new event [' + result.insertedIds + ']');
+				}
+			});
+	})
+	.then(function () {
+		// create response body
+		var response = 'now implementing.';
+		res.send(response);
+	})	.catch(function (err) {
+		console.log(err);
+	});
+});
+
+module.exports = router;

--- a/routes/group.js
+++ b/routes/group.js
@@ -65,34 +65,12 @@ router.post('/:group/event/join', function (req, res) {
 		return;
 	}
 
-	if (!isValidJoinParameters(req)) {
-		res.status(400).send({error: 'some parameters are not correct.'});
-		return;
-	}
-
-	// check if the requested event has been fixed event
-	if (isFixedDate(req.body.year + '-' + req.body.month + '-' + req.body.day, req.body.eventType)) {
-		res.status(400).send({error: 'already fixed.'});
-		return;
-	}
-
 	var user = [];
 	var joinedEvents = [];
 	var days = [];
 	var isNeedCreateJoinRecord = true;
 
 	Promise.resolve()
-	.then(function () {
-		// check if group exists.
-		return db.collection('groups').findOneAsync({id: req.params.group})
-			.then(function (result) {
-				if (result === null) {
-					var errBody = {error: 'group does not exists.'};
-					res.status(404).send(errBody);
-					return Promise.reject(errBody);
-				}
-			});
-	})
 	.then(function () {
 		// check if user exists
 		return db.collection('users').findOneAsync({token: xToken})
@@ -104,6 +82,32 @@ router.post('/:group/event/join', function (req, res) {
 				}
 
 				user = result;
+			});
+	})
+	.then(function () {
+		if (!isValidJoinParameters(req)) {
+			var errBody = {error: 'some parameters are not correct.'};
+			res.status(400).send(errBody);
+			return Promise.reject(errBody);
+		}
+	})
+	.then(function () {
+		// check if the requested event has been fixed event
+		if (isFixedDate(req.body.year + '-' + req.body.month + '-' + req.body.day, req.body.eventType)) {
+			var errBody = {error: 'already fixed.'};
+			res.status(400).send(errBody);
+			return Promise.reject(errBody);
+		}
+	})
+	.then(function () {
+		// check if group exists.
+		return db.collection('groups').findOneAsync({id: req.params.group})
+			.then(function (result) {
+				if (result === null) {
+					var errBody = {error: 'group does not exists.'};
+					res.status(404).send(errBody);
+					return Promise.reject(errBody);
+				}
 			});
 	})
 	.then(function () {

--- a/routes/group.js
+++ b/routes/group.js
@@ -9,7 +9,7 @@ bluebird.promisifyAll(mongoskin);
 var validator = require('validator');
 var moment = require('moment');
 
-var API_VERSION = '1.0';
+var API_VERSION = 1.0;
 
 /**
  * dicide the date sent whether fixed
@@ -59,6 +59,12 @@ var isValidJoinParameters = function (req) {
 router.post('/:group/event/join', function (req, res) {
 	// accepting request and validation
 	// <TODO> 上位処理に移行予定
+	var xToken = req.get('X-Meshido-UserToken');
+	if (xToken === undefined) {
+		res.status(401).send({error: 'no token was send.'});
+		return;
+	}
+
 	if (!isValidJoinParameters(req)) {
 		res.status(400).send({error: 'some parameters are not correct.'});
 		return;
@@ -67,12 +73,6 @@ router.post('/:group/event/join', function (req, res) {
 	// check if the requested event has been fixed event
 	if (isFixedDate(req.body.year + '-' + req.body.month + '-' + req.body.day, req.body.eventType)) {
 		res.status(400).send({error: 'already fixed.'});
-		return;
-	}
-
-	var xToken = req.get('X-Meshido-UserToken');
-	if (xToken === undefined) {
-		res.status(401).send({error: 'no token was send.'});
 		return;
 	}
 
@@ -99,7 +99,7 @@ router.post('/:group/event/join', function (req, res) {
 			.then(function (result) {
 				if (result === null) {
 					var errBody = {error: 'user does not exists.'};
-					res.status(404).send(errBody);
+					res.status(401).send(errBody);
 					return Promise.reject(errBody);
 				}
 
@@ -216,7 +216,7 @@ router.post('/:group/event/join', function (req, res) {
 						// initialize default data
 						days.push(
 							{
-								dayOfMonth: date.format('D'),
+								dayOfMonth: parseInt(date.format('D')),
 								weekday: date.format('ddd'),
 								dinner: {
 									hasJoined: false,

--- a/routes/index.js
+++ b/routes/index.js
@@ -9,7 +9,7 @@ var bluebird = require('bluebird');
 bluebird.promisifyAll(mongoskin);
 var validator = require('validator');
 
-var API_VERSION = '1.0';
+var API_VERSION = 1.0;
 
 /* GET home page. */
 router.get('/', function (req, res) {
@@ -206,7 +206,7 @@ router.get('/logout', function (req, res) {
 	var xToken = req.get('X-Meshido-UserToken');
 	if (xToken === undefined) {
 		var errBody = {error: 'no token was send.'};
-		res.status(400).send(errBody);
+		res.status(401).send(errBody);
 		return;
 	}
 

--- a/tools/dbInit.js
+++ b/tools/dbInit.js
@@ -16,11 +16,11 @@ console.log('remove all user data');
 db.collection('users').removeAsync()
 .then(function () {
 	console.log('remove all groups data');
-	return db.collection('groups').find().toArrayAsync();
+	return db.collection('groups').removeAsync();
 })
 .then(function () {
 	console.log('remove all events data');
-	return db.collection('events').find().toArrayAsync();
+	return db.collection('events').removeAsync();
 })
 .then(function () {
 	console.log('insert initial data for group');


### PR DESCRIPTION
参加API実装しました
一部未実装です。
### 未実装箇所

Responseの確定済み[isFixed]フラグの判定
Responseの_linksの設定
### 事前準備
1. リポジトリをcloneし、このブランチに切り替える
2. `npm install`を実行
3. `npm run init-db`を実行してDBを初期化する
4. `npm run start-dev`を実行してサーバーを起動する
### 確認内容

以下の手順を実行して、正常にResponseがかえること
#### 1.夜に参加

<要点>
dayofmonthとweekdayが正しいこと
dinnerの参加者数が1
dinnerのhasJoinedがtrue
lunchの参加者数が0
lunchのhasJoinedがfalse
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "山田太郎",
    "email": "taro@example.com",
    "group": "test1"
 }
```
- /group/test1/event/join に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015", // 未来の日付
  "month": "12",
  "day": "20",
  "eventType": "dinner"
}
```

Response

```
{
    "v": 1,
    "result": "success",
    "days": [
        {
            "dayOfMonth": 20,
            "weekday": "Sun",
            "dinner": {
                "hasJoined": true,
                "isFixed": false,
                "participantCount": 1,
                "_links": []
            },
            "lunch": {
                "hasJoined": false,
                "isFixed": false,
                "participantCount": 0,
                "_links": []
            }
        }
    ]
}

```
#### 2.既に参加済み

<要点>
エラーにならず、かつ参加者数が増えないこと（エラーにするのではなく、現在の参加状況を返却するようにしました）
dayofmonthとweekdayが正しいこと
dinnerの参加者数が1
dinnerのhasJoinedがtrue
lunchの参加者数が0
lunchのhasJoinedがfalse
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "山田太郎",
    "email": "taro@example.com",
    "group": "test1"
 }
```
- /group/test1/event/join に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015", // 未来の日付
  "month": "12",
  "day": "20",
  "eventType": "dinner"
}
```

Response

```
{
    "v": 1,
    "result": "success",
    "days": [
        {
            "dayOfMonth": 20,
            "weekday": "Sun",
            "dinner": {
                "hasJoined": true,
                "isFixed": false,
                "participantCount": 1,
                "_links": []
            },
            "lunch": {
                "hasJoined": false,
                "isFixed": false,
                "participantCount": 0,
                "_links": []
            }
        }
    ]
}

```
#### 3.お昼に参加

<要点>
dayofmonthとweekdayが正しいこと
dinnerの参加者数が1  // 1.で参加済み
dinnerのhasJoinedがtrue  // 1.で参加済み
lunchの参加者数が1
lunchのhasJoinedがtrue
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "山田太郎",
    "email": "taro@example.com",
    "group": "test1"
 }
```
- /group/test1/event/join に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015", // 未来の日付
  "month": "12",
  "day": "20",
  "eventType": "lunch"
}
```

Response

```
{
    "v": 1,
    "result": "success",
    "days": [
        {
            "dayOfMonth": 20,
            "weekday": "Sun",
            "dinner": {
                "hasJoined": true,
                "isFixed": false,
                "participantCount": 1,
                "_links": []
            },
            "lunch": {
                "hasJoined": true,
                "isFixed": false,
                "participantCount": 1,
                "_links": []
            }
        }
    ]
}

```
#### 4.別の日に参加

<要点>
dayofmonthとweekdayが正しいこと
dinnerの参加者数が1
dinnerのhasJoinedがtrue
lunchの参加者数が0
lunchのhasJoinedがfalse
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "山田太郎",
    "email": "taro@example.com",
    "group": "test1"
 }
```
- /group/test1/event/join に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015", // 未来の日付
  "month": "12",
  "day": "21",
  "eventType": "dinner"
}
```

Response

```
{
    "v": 1,
    "result": "success",
    "days": [
        {
            "dayOfMonth": 21,
            "weekday": "Mon",
            "dinner": {
                "hasJoined": true,
                "isFixed": false,
                "participantCount": 1,
                "_links": []
            },
            "lunch": {
                "hasJoined": false,
                "isFixed": false,
                "participantCount": 0,
                "_links": []
            }
        }
    ]
}

```
#### 5.別のユーザーで参加

<要点>
dayofmonthとweekdayが正しいこと
dinnerの参加者数が2
dinnerのhasJoinedがtrue
lunchの参加者数が1
lunchのhasJoinedがfalse
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "鈴木次郎",
    "email": "jiro@example.com",
    "group": "test1"
 }
```
- /group/test1/event/join に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015", // 未来の日付
  "month": "12",
  "day": "20",
  "eventType": "dinner"
}
```

Response

```
{
    "v": 1,
    "result": "success",
    "days": [
        {
            "dayOfMonth": 21,
            "weekday": "Mon",
            "dinner": {
                "hasJoined": true,
                "isFixed": false,
                "participantCount": 2,
                "_links": []
            },
            "lunch": {
                "hasJoined": false,
                "isFixed": false,
                "participantCount": 1,
                "_links": []
            }
        }
    ]
}

```
#### 6-1.パラメータ不備

<要点>
エラーチェックされてること

Request

トークン渡さなかったり、日付の一部が抜けてたり、日付に文字列渡したり、ありえない日付(12月32日とか)を渡したり適当にやってください

Response

過去の日付を渡す（厳密にはlunchなら11時、dinnerなら17時以降は当日も受付不可）

```
401 Unauthorized
{
    "error": "already fixed."
}

```

トークンなし

```
401 Unauthorized
{
    "error": "no token was send."
}

```

トークン正しくない

```
401 Unauthorized
{
    "error": "user does not exists."
}


```

グループID不正

```
404 Not Found
{
    "error": "group does not exists."
}

```

その他のパラメータエラー

```
400 Bad Request
{
    "error": "some parameters are not correct."
}

```
