### PR TITLE
8/calendar ap iprototype

### DIFF
--- a/routes/group.js
+++ b/routes/group.js
@@ -265,4 +265,65 @@ router.post('/:group/event/join', function (req, res) {
 	});
 });
 
+
+
+/**
+ * calendar
+ */
+var getCalendarAction = function (req, res) {
+
+	var days = [];
+
+	Promise.resolve()
+	.then(function () {
+		// create mock response
+		var daysInMonth = moment().daysInMonth();
+		// initializing this month's days
+		for (i=1; i <= daysInMonth; i++) {
+			var aDayMoment = moment().date(i);
+			var aDay =
+				{
+					dayOfMonth: parseInt(aDayMoment.format('D'), 10),
+					weekday: aDayMoment.format('ddd'),
+					dinner: {
+						hasJoined: false,
+						isFixed: isFixedDate(aDayMoment.format('YYYY-MM-DD'), 'dinner'),
+						participantCount: 0,
+						// <TODO> まだ
+						_links: []
+					},
+					lunch: {
+						hasJoined: false,
+						isFixed: isFixedDate(aDayMoment.format('YYYY-MM-DD'), 'lunch'),
+						participantCount: 0,
+						// <TODO> まだ
+						_links: []
+					}
+				};
+			days.push(aDay);
+		}
+
+		// apply mock data
+		for (i=0; i < daysInMonth; i++) {
+			days[i].dinner.hasJoined = (i % 3 === 0);
+			days[i].dinner.participantCount = i % 4;
+			days[i].lunch.hasJoined = (i % 5 === 0);
+			days[i].lunch.participantCount = i % 6;
+		}
+
+		res.send(days);
+	})
+	.catch(function (err) {
+		console.log(err);
+	});
+};
+
+/**
+ * routing calendar
+ */
+router.get('/:group/calendar', getCalendarAction);
+router.get('/:group/calendar/year/:year', getCalendarAction);
+router.get('/:group/calendar/year/:year/month/:month', getCalendarAction);
+router.get('/:group/calendar/year/:year/month/:month/day/:day', getCalendarAction);
+
 module.exports = router;

--- a/routes/group.js
+++ b/routes/group.js
@@ -311,7 +311,13 @@ var getCalendarAction = function (req, res) {
 			days[i].lunch.participantCount = i % 6;
 		}
 
-		res.send(days);
+		// create response body
+		var response = {
+			v: API_VERSION,
+			days: days
+		};
+
+		res.send(response);
 	})
 	.catch(function (err) {
 		console.log(err);

--- a/routes/group.js
+++ b/routes/group.js
@@ -424,12 +424,9 @@ var getCalendarAction = function (req, res) {
 					var aDayIndex = aRow._id.d - 1;
 					var eventType = aRow._id.type;
 
-					days[aDayIndex][eventType] = {
-						hasJoined: (joinedEvents[date.format('D') + '-' + eventType] !== undefined),
-						participantCount: aRow.count,
-						// <TODO> まだ
-						_links: []
-					};
+					var anEvent = days[aDayIndex][eventType];
+					anEvent.hasJoined = (joinedEvents[date.format('D') + '-' + eventType] !== undefined);
+					anEvent.participantCount = aRow.count;
 				});
 			});
 	})


### PR DESCRIPTION
calendarAPI実装しました
一部未実装です。
### 未実装箇所

Responseの_linksの設定
年月日の「日」まで渡すとその日だけ取ってくる、っていう機能
⇛must機能じゃないはずなので機能として落とします…。僕もうつかれたじょ
### 事前準備
1. リポジトリをcloneし、このブランチに切り替える
2. `npm install`を実行
3. `npm run init-db`を実行してDBを初期化する
4. `npm run start-dev`を実行してサーバーを起動する
### 確認内容

以下の手順を実行して、正常にResponseがかえること
#### 1.年月指定なしで今月のcalendarが取得できること
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "山田太郎",
    "email": "taro@example.com",
    "group": "test1"
 }
```
- /group/test1/calendar に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
```

Response

実行した年・月のdaysが取得できること。
　⇛何日かピックアップして、dayOfMonthとweekdayの対応が一致していれば大体OKと思います。
全てのイベントのparticipantCountが0であること
　⇛何日かピックアップして、見てもらえればOKと思います
全てのイベントのhasJoinedが0であること
　⇛何日かピックアップして、見てもらえればOKと思います
イベント締め切り時刻より前のイベントのisFixedがtrueであること
　⇛ex.) 12/19の12時に実行すると 12/1-12/18のlunch/dinnerと12/19のlunchのisFixedがtrue
#### 2.年月を指定するとその月のcalendarが取得できること
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "山田太郎",
    "email": "taro@example.com",
    "group": "test1"
 }
```
- /group/test1/calendar/year/2016/month/2 に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
```

Response

2016年2月のdaysが取得できること。
　⇛何日かピックアップして、dayOfMonthとweekdayの対応が一致していれば大体OKと思います。
全てのイベントのparticipantCountが0であること
　⇛何日かピックアップして、見てもらえればOKと思います
全てのイベントのhasJoinedが0であること
　⇛何日かピックアップして、見てもらえればOKと思います
#### 3.イベントに参加すると、calendarに反映されること
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "山田太郎",
    "email": "taro@example.com",
    "group": "test1"
 }
```
- /group/test1/event/join に以下のパラメータを送信してResponseを確認する

<1個目>
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "21",
  "eventType": "dinner"
}
```

<2個目>
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "22",
  "eventType": "lunch"
}
```

<3個目>
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "22",
  "eventType": "dinner"
}
```
- /group/test1/calendar に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
```

Response

取得したresponseが以下の通りであること。
 12/21 の lunch について
  hasJoined:false
  participantCount:0
 12/21 の dinner について
  hasJoined:true
  participantCount:1
 12/22 の lunch について
  hasJoined:true
  participantCount:1
 12/22 の dinner について
  hasJoined:true
  participantCount:1
#### 4.別のユーザーで参加後、他ユーザーの参加情報も含めて取得できること
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "鈴木次郎",
    "email": "jiro@example.com",
    "group": "test1"
 }
```
- /group/test1/event/join に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "22",
  "eventType": "lunch"
}
```
- /group/test1/calendar に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
```

Response

取得したresponseが以下の通りであること。
 12/21 の lunch について // 誰も参加してない
  hasJoined:false
  participantCount:0
 12/21 の dinner について // 山田太郎のみ参加
  hasJoined:false
  participantCount:1
 12/22 の lunch について // 山田太郎も鈴木次郎も参加
  hasJoined:true
  participantCount:2
 12/22 の dinner について // 山田太郎のみ参加
  hasJoined:false
  participantCount:1
#### 6-1.パラメータ不備

トークンなし

```
401 Unauthorized
{
    "error": "no token was send."
}

```

トークン正しくない

```
401 Unauthorized
{
    "error": "user does not exists."
}


```

グループID不正

```
404 Not Found
{
    "error": "group does not exists."
}

```
