### PR TITLE
20/cancel api

### DIFF
--- a/routes/group.js
+++ b/routes/group.js
@@ -30,24 +30,24 @@ var isFixedDate = function (ymdStr, evenType) {
 /**
  * validate join params
  */
-var isValidJoinParameters = function (req) {
+var isValidJoinParameters = function (group, year, month, day, eventType) {
 	var isValid = true;
-	if (validator.isNull(req.params.group)) {
+	if (validator.isNull(group)) {
 		isValid = false;
 	}
-	if (validator.isNull(req.body.year)) {
+	if (validator.isNull(year)) {
 		isValid = false;
 	}
-	if (validator.isNull(req.body.month)) {
+	if (validator.isNull(month)) {
 		isValid = false;
 	}
-	if (validator.isNull(req.body.day)) {
+	if (validator.isNull(day)) {
 		isValid = false;
 	}
-	if (req.body.eventType !== 'lunch' && req.body.eventType !== 'dinner') {
+	if (eventType !== 'lunch' && eventType !== 'dinner') {
 		isValid = false;
 	}
-	if (!validator.isDate(req.body.year + '-' + req.body.month + '-' + req.body.day)) {
+	if (!validator.isDate(year + '-' + month + '-' + day)) {
 		isValid = false;
 	}
 	return isValid;
@@ -64,6 +64,12 @@ router.post('/:group/event/join', function (req, res) {
 		res.status(401).send({error: 'no token was send.'});
 		return;
 	}
+
+	var joinGroup = String(req.params.group);
+	var joinYear = Number(req.body.year);
+	var joinMonth = Number(req.body.month);
+	var joinDay = Number(req.body.day);
+	var joinEventType = String(req.body.eventType);
 
 	var user = [];
 	var joinedEvents = [];
@@ -85,7 +91,7 @@ router.post('/:group/event/join', function (req, res) {
 			});
 	})
 	.then(function () {
-		if (!isValidJoinParameters(req)) {
+		if (!isValidJoinParameters(joinGroup, joinYear, joinMonth, joinDay, joinEventType)) {
 			var errBody = {error: 'some parameters are not correct.'};
 			res.status(400).send(errBody);
 			return Promise.reject(errBody);
@@ -93,7 +99,7 @@ router.post('/:group/event/join', function (req, res) {
 	})
 	.then(function () {
 		// check if the requested event has been fixed event
-		if (isFixedDate(req.body.year + '-' + req.body.month + '-' + req.body.day, req.body.eventType)) {
+		if (isFixedDate(joinYear + '-' + joinMonth + '-' + joinDay, joinEventType)) {
 			var errBody = {error: 'already fixed.'};
 			res.status(400).send(errBody);
 			return Promise.reject(errBody);
@@ -101,7 +107,7 @@ router.post('/:group/event/join', function (req, res) {
 	})
 	.then(function () {
 		// check if group exists.
-		return db.collection('groups').findOneAsync({id: req.params.group})
+		return db.collection('groups').findOneAsync({id: joinGroup})
 			.then(function (result) {
 				if (result === null) {
 					var errBody = {error: 'group does not exists.'};
@@ -114,11 +120,11 @@ router.post('/:group/event/join', function (req, res) {
 		// check if user has already joined
 		return db.collection('events').findOneAsync(
 			{
-				'group': req.params.group,
-				'year': req.body.year,
-				'month': req.body.month,
-				'day': req.body.day,
-				'type': req.body.eventType,
+				'group': joinGroup,
+				'year': joinYear,
+				'month': joinMonth,
+				'day': joinDay,
+				'type': joinEventType,
 				'user.email': user.email
 			}
 		)
@@ -132,11 +138,11 @@ router.post('/:group/event/join', function (req, res) {
 		// join event
 		if (isNeedCreateJoinRecord) {
 			var event = {
-				group: req.params.group,
-				year: req.body.year,
-				month: req.body.month,
-				day: req.body.day,
-				type: req.body.eventType,
+				group: joinGroup,
+				year: joinYear,
+				month: joinMonth,
+				day: joinDay,
+				type: joinEventType,
 				user: {
 					name: user.name,
 					email: user.email
@@ -155,10 +161,10 @@ router.post('/:group/event/join', function (req, res) {
 		// retribe my joined events
 		return db.collection('events').find(
 			{
-				'group': req.params.group,
-				'year': req.body.year,
-				'month': req.body.month,
-				'day': req.body.day,
+				'group': joinGroup,
+				'year': joinYear,
+				'month': joinMonth,
+				'day': joinDay,
 				'user.email': user.email
 			}
 		)
@@ -178,10 +184,10 @@ router.post('/:group/event/join', function (req, res) {
 				// matching condition
 				{
 					$match: {
-						group: req.params.group,
-						year: req.body.year,
-						month: req.body.month,
-						day: req.body.day
+						group: joinGroup,
+						year: joinYear,
+						month: joinMonth,
+						day: joinDay
 					}
 				},
 				// sorting condition
@@ -268,14 +274,21 @@ router.post('/:group/event/join', function (req, res) {
 /**
  * validate join params
  */
-var isValidCalendarParameters = function (req, year, month) {
+var isValidCalendarParameters = function (group, year, month) {
 	var isValid = true;
-	if (validator.isNull(req.params.group)) {
+	if (validator.isNull(group)) {
+		isValid = false;
+	}
+	if (validator.isNull(year)) {
+		isValid = false;
+	}
+	if (validator.isNull(month)) {
 		isValid = false;
 	}
 	if (!validator.isDate(year + '-' + month + '-01')) {
 		isValid = false;
 	}
+	console.log(validator.isDate(year + '-' + month + '-01'));
 	return isValid;
 };
 
@@ -294,6 +307,10 @@ var getCalendarAction = function (req, res) {
 	var currentMoment = moment();
 	var searchYear = (req.params.year === undefined) ? currentMoment.format('YYYY') : req.params.year;
 	var searchMonth = (req.params.month === undefined) ? currentMoment.format('M') : req.params.month;
+
+	var searchGroup = String(req.params.group);
+	searchYear = Number(searchYear);
+	searchMonth = Number(searchMonth);
 
 	var user = [];
 	var joinedEvents = [];
@@ -314,7 +331,7 @@ var getCalendarAction = function (req, res) {
 			});
 	})
 	.then(function () {
-		if (!isValidCalendarParameters(req, searchYear, searchMonth)) {
+		if (!isValidCalendarParameters(searchGroup, searchYear, searchMonth)) {
 			var errBody = {error: 'some parameters are not correct.'};
 			res.status(400).send(errBody);
 			return Promise.reject(errBody);
@@ -322,7 +339,7 @@ var getCalendarAction = function (req, res) {
 	})
 	.then(function () {
 		// check if group exists.
-		return db.collection('groups').findOneAsync({id: req.params.group})
+		return db.collection('groups').findOneAsync({id: searchGroup})
 			.then(function (result) {
 				if (result === null) {
 					var errBody = {error: 'group does not exists.'};
@@ -335,7 +352,7 @@ var getCalendarAction = function (req, res) {
 		// retribe my joined events
 		return db.collection('events').find(
 			{
-				'group': req.params.group,
+				'group': searchGroup,
 				'year': searchYear,
 				'month': searchMonth,
 				'user.email': user.email
@@ -386,7 +403,7 @@ var getCalendarAction = function (req, res) {
 				// matching condition
 				{
 					$match: {
-						group: req.params.group,
+						group: searchGroup,
 						year: searchYear,
 						month: searchMonth
 					}
@@ -454,24 +471,24 @@ router.get('/:group/calendar/year/:year/month/:month', getCalendarAction);
 /**
  * validate cancel params
  */
-var isValidCancelParameters = function (req) {
+var isValidCancelParameters = function (group, year, month, day, eventType) {
 	var isValid = true;
-	if (validator.isNull(req.params.group)) {
+	if (validator.isNull(group)) {
 		isValid = false;
 	}
-	if (validator.isNull(req.body.year)) {
+	if (validator.isNull(year)) {
 		isValid = false;
 	}
-	if (validator.isNull(req.body.month)) {
+	if (validator.isNull(month)) {
 		isValid = false;
 	}
-	if (validator.isNull(req.body.day)) {
+	if (validator.isNull(day)) {
 		isValid = false;
 	}
-	if (req.body.eventType !== 'lunch' && req.body.eventType !== 'dinner') {
+	if (eventType !== 'lunch' && eventType !== 'dinner') {
 		isValid = false;
 	}
-	if (!validator.isDate(req.body.year + '-' + req.body.month + '-' + req.body.day)) {
+	if (!validator.isDate(year + '-' + month + '-' + day)) {
 		isValid = false;
 	}
 	return isValid;
@@ -488,6 +505,12 @@ router.post('/:group/event/cancel', function (req, res) {
 		res.status(401).send({error: 'no token was send.'});
 		return;
 	}
+
+	var cancelGroup = String(req.params.group);
+	var cancelYear = Number(req.body.year);
+	var cancelMonth = Number(req.body.month);
+	var cancelDay = Number(req.body.day);
+	var cancelEventType = String(req.body.eventType);
 
 	var user = [];
 	var joinedEvents = [];
@@ -508,7 +531,7 @@ router.post('/:group/event/cancel', function (req, res) {
 			});
 	})
 	.then(function () {
-		if (!isValidCancelParameters(req)) {
+		if (!isValidCancelParameters(cancelGroup, cancelYear, cancelMonth, cancelDay, cancelEventType)) {
 			var errBody = {error: 'some parameters are not correct.'};
 			res.status(400).send(errBody);
 			return Promise.reject(errBody);
@@ -516,7 +539,7 @@ router.post('/:group/event/cancel', function (req, res) {
 	})
 	.then(function () {
 		// check if the requested event has been fixed event
-		if (isFixedDate(req.body.year + '-' + req.body.month + '-' + req.body.day, req.body.eventType)) {
+		if (isFixedDate(cancelYear + '-' + cancelMonth + '-' + cancelDay, cancelEventType)) {
 			var errBody = {error: 'already fixed.'};
 			res.status(400).send(errBody);
 			return Promise.reject(errBody);
@@ -524,7 +547,7 @@ router.post('/:group/event/cancel', function (req, res) {
 	})
 	.then(function () {
 		// check if group exists.
-		return db.collection('groups').findOneAsync({id: req.params.group})
+		return db.collection('groups').findOneAsync({id: cancelGroup})
 			.then(function (result) {
 				if (result === null) {
 					var errBody = {error: 'group does not exists.'};
@@ -537,11 +560,11 @@ router.post('/:group/event/cancel', function (req, res) {
 		// check if user has already joined
 		return db.collection('events').removeAsync(
 			{
-				'group': req.params.group,
-				'year': req.body.year,
-				'month': req.body.month,
-				'day': req.body.day,
-				'type': req.body.eventType,
+				'group': cancelGroup,
+				'year': cancelYear,
+				'month': cancelMonth,
+				'day': cancelDay,
+				'type': cancelEventType,
 				'user.email': user.email
 			}
 		);
@@ -550,10 +573,10 @@ router.post('/:group/event/cancel', function (req, res) {
 		// retribe my joined events
 		return db.collection('events').find(
 			{
-				'group': req.params.group,
-				'year': req.body.year,
-				'month': req.body.month,
-				'day': req.body.day,
+				'group': cancelGroup,
+				'year': cancelYear,
+				'month': cancelMonth,
+				'day': cancelDay,
 				'user.email': user.email
 			}
 		)
@@ -573,10 +596,10 @@ router.post('/:group/event/cancel', function (req, res) {
 				// matching condition
 				{
 					$match: {
-						group: req.params.group,
-						year: req.body.year,
-						month: req.body.month,
-						day: req.body.day
+						group: cancelGroup,
+						year: cancelYear,
+						month: cancelMonth,
+						day: cancelDay
 					}
 				},
 				// sorting condition
@@ -604,7 +627,7 @@ router.post('/:group/event/cancel', function (req, res) {
 				}
 			];
 
-		var dateYMDStr = [req.body.year, req.body.month, req.body.day].join('-');
+		var dateYMDStr = [cancelYear, cancelMonth, cancelDay].join('-');
 		var date = moment(dateYMDStr);
 
 		// initialize default data


### PR DESCRIPTION
キャンセルAPI実装しました
一部未実装です。
### 未実装箇所

Responseの_linksの設定
### 事前準備
1. リポジトリをcloneし、このブランチに切り替える
2. `npm install`を実行
3. `npm run init-db`を実行してDBを初期化する
4. `npm run start-dev`を実行してサーバーを起動する
### 確認内容

以下の手順を実行して、正常にResponseがかえること
#### 1.参加->カレンダーで確認->キャンセル->カレンダーで確認
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "山田太郎",
    "email": "taro@example.com",
    "group": "test1"
 }
```
- /group/test1/event/join に以下のパラメータを送信していくつかのイベントを参加状態にする

<1個目>
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "21",
  "eventType": "dinner"
}
```

<2個目>
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "21",
  "eventType": "lunch"
}
```

<3個目>
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "22",
  "eventType": "dinner"
}
```

<4個目>
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "22",
  "eventType": "lunch"
}
```
- /group/test1/calendar に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
```

Response

取得したresponseが以下の通りであること。
 12/21 の lunch について
  hasJoined:true
  participantCount:1
 12/21 の dinner について
  hasJoined:true
  participantCount:1
 12/22 の lunch について
  hasJoined:true
  participantCount:1
 12/22 の dinner について
  hasJoined:true
  participantCount:1
- /group/test1/event/cancel に以下のパラメータを送信していくつかのイベント参加をキャンセルする

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "21",
  "eventType": "dinner"
}
```
- /group/test1/calendar に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
```

Response

取得したresponseが以下の通りであること。
 12/21 の lunch について
  hasJoined:true
  participantCount:1
 12/21 の dinner について
  hasJoined:false
  participantCount:0
 12/22 の lunch について
  hasJoined:true
  participantCount:1
 12/22 の dinner について
  hasJoined:true
  participantCount:1
#### 2.別のユーザーでもやってみる
- /login を以下のパラメータで実行し、トークンを取得する

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
Body
 {
    "name": "鈴木次郎",
    "email": "jiro@example.com",
    "group": "test1"
 }
```
- /group/test1/event/join に以下のパラメータを送信していくつかのイベントを参加状態にする

<1個目>
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "22",
  "eventType": "dinner"
}
```

<2個目>
Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "22",
  "eventType": "lunch"
}
```
- /group/test1/calendar に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
```

Response

取得したresponseが以下の通りであること。
 12/21 の lunch について // 山田太郎のみ
  hasJoined:false
  participantCount:1
 12/21 の dinner について
  hasJoined:false
  participantCount:0
 12/22 の lunch について　//　山田太郎と鈴木次郎
  hasJoined:true
  participantCount:2
 12/22 の dinner について　//　山田太郎と鈴木次郎
  hasJoined:true
  participantCount:2
- /group/test1/event/cancel に以下のパラメータを送信していくつかのイベント参加をキャンセルする

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
Body
{
  "year": "2015",
  "month": "12",
  "day": "22",
  "eventType": "lunch"
}
```
- /group/test1/calendar に以下のパラメータを送信してResponseを確認する

Request

```
Header
 Content-Type: application/json;
 X-Meshido-ApiVersion: 1.0;
 X-Meshido-UserToken: [ログインで取得したトークン]
```

Response

取得したresponseが以下の通りであること。
 12/21 の lunch について  // 山田太郎のみ
  hasJoined:false
  participantCount:1
 12/21 の dinner について
  hasJoined:false
  participantCount:0
 12/22 の lunch について　// 山田太郎のみ
  hasJoined:false
  participantCount:1
 12/22 の dinner について　// 山田太郎と鈴木次郎
  hasJoined:true
  participantCount:2
#### 6-1.パラメータ不備

<要点>
エラーチェックされてること

Request

トークン渡さなかったり、日付の一部が抜けてたり、日付に文字列渡したり、ありえない日付(12月32日とか)を渡したり適当にやってください

Response

過去の日付を渡す（厳密にはlunchなら11時、dinnerなら17時以降は当日も受付不可）

```
401 Unauthorized
{
    "error": "already fixed."
}

```

トークンなし

```
401 Unauthorized
{
    "error": "no token was send."
}

```

トークン正しくない

```
401 Unauthorized
{
    "error": "user does not exists."
}


```

グループID不正

```
404 Not Found
{
    "error": "group does not exists."
}

```

その他のパラメータエラー

```
400 Bad Request
{
    "error": "some parameters are not correct."
}

```
