### PR TITLE
グループIDを外部注入できるように変更

### DIFF
--- a/src/batch/eventNotifier.js
+++ b/src/batch/eventNotifier.js
@@ -4,6 +4,8 @@ var db = mongoskin.db(process.env.MONGO_URI);
 var bluebird = require('bluebird');
 bluebird.promisifyAll(mongoskin);
 
+var procGroup = process.env.PROC_GROUP || 'test1';
+
 /**
  * USAGE:
  *
@@ -39,7 +41,7 @@ if (jstHour === 11) {
 }
 
 db.collection('events').find({
-	group: 'test1',
+	group: procGroup,
 	year: jstYear,
 	month: jstMonth,
 	day: jstDay,


### PR DESCRIPTION
バッチ動作時のグループIDを環境変数[PROC_GROUP]から取得するようにしました
### 確認内容
1. `npm run init-db`でmongoDBを初期化する
2. ログインする

```
POST http://localhost:3000/login
{
    "name": "山田太郎",
    "email": "{存在するメールアドレス}",
    "group": "test1"
 }
```

3.ランチに参加する

```
POST http://localhost:3000/group/test1/event/join
 {
  "year": 2016,
  "month": 11,
  "day": 5,
  "eventType": "lunch"
}
```
1. バッチを実行し、指定したグループIDで参加者数が正しく取得できていることを確認する

```
$ MESHIDO_SENDGRID_API_KEY='[sendgridのAPIキー]' MONGO_URI='mongodb://localhost:27017/meshido' PROC_GROUP='test1' node src/batch/eventNotifier.js 2016 1 5 11 2
```

以下のログが表示されること

```
Participant count (1) is less than threshold (2).
```
1. 環境変数のグループIDを変更して再度実行し、グループIDの指定が正しく適用されていることを確認する

```
$ MESHIDO_SENDGRID_API_KEY='[sendgridのAPIキー]' MONGO_URI='mongodb://localhost:27017/meshido' PROC_GROUP='test2' node src/batch/eventNotifier.js 2016 1 5 11 2
```

以下のログが表示されること

```
Participant count (0) is less than threshold (2).
```
